### PR TITLE
Only clear xhr responses of non-successful uploads

### DIFF
--- a/client/js/upload-handler/upload.handler.controller.js
+++ b/client/js/upload-handler/upload.handler.controller.js
@@ -269,7 +269,14 @@ qq.UploadHandlerController = function(o, namespace) {
                                 }
                             )
                                 .done(function () {
-                                    handler.clearXhr(id, chunkIdx);
+                                    var xhr = handler._getXhr(id, chunkIdx);
+
+                                    if (xhr && xhr.response) {
+                                      var xhrr = JSON.parse(xhr.response);
+                                      if (!xhrr.hasOwnProperty('files')) {
+                                        handler.clearXhr(id, chunkIdx);
+                                      }
+                                    }
                                 });
                         }
                     },


### PR DESCRIPTION
When FineUploader is configured to upload file chunks concurrently it preserves only the last response returned.

This is problematic as successful file upload responses can return out of order.

Send out : 1/3, 2/3, 3/3 (last sent chunk) at the same time
Receive: 1/3, 3/3 (success response, will get discarded, is what finalizeChunks references), 2/3.  

This causes the finalizeChunks function to fail as it references the last sent chunk 

https://github.com/estimateone/fine-uploader/blob/641577a9ce67f12a183e81bfb19fdb4c4f34a0ea/client/js/upload-handler/xhr.upload.handler.js#L109-L120


This PR forces the `UploadHanderController` to hold on to all successful file upload responses so that in the example above 3/3 would not be cleared

